### PR TITLE
FTMO/OANDA trading scaffold with timeframe-adaptive risk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@ _site/
 .sass-cache/
 .jekyll-metadata
 .bundle
+
+# Python (ftmo_oanda)
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+.env
+.pytest_cache/

--- a/ftmo_oanda/.env.example
+++ b/ftmo_oanda/.env.example
@@ -1,0 +1,18 @@
+# OANDA v20 API credentials
+# Get these from https://www.oanda.com/demo-account/tpa/personal_token (practice)
+# or https://www.oanda.com/account/tpa/personal_token (live)
+OANDA_API_TOKEN=your_token_here
+OANDA_ACCOUNT_ID=101-001-1234567-001
+OANDA_ENVIRONMENT=practice  # practice or live
+
+# FTMO challenge parameters (defaults match the standard $100k challenge)
+FTMO_INITIAL_BALANCE=100000
+FTMO_PROFIT_TARGET_PCT=10
+FTMO_MAX_DAILY_LOSS_PCT=5
+FTMO_MAX_TOTAL_LOSS_PCT=10
+FTMO_MAX_LEVERAGE=30  # FTMO caps forex leverage at 1:30 on the swing-style; 1:100 standard
+
+# Trading parameters
+INSTRUMENTS=EUR_USD,GBP_USD,USD_JPY,XAU_USD
+TIMEFRAME=H1  # M5, M15, M30, H1, H4, D
+DRY_RUN=true  # set false to place real orders

--- a/ftmo_oanda/README.md
+++ b/ftmo_oanda/README.md
@@ -1,0 +1,124 @@
+# FTMO / OANDA trading scaffold
+
+A realistic, FTMO-aware algorithmic trading bot built on the OANDA v20 REST API.
+Settings, position size, leverage, ATR brackets, and signal cadence **auto-adjust
+to whatever timeframe you select** (M1 through D), so the same code runs sensibly
+on a scalping setup or a swing setup.
+
+> **Honest expectations.** This is not the viral-Twitter "90% win rate" system.
+> A well-engineered trend-following bot like this one typically wins 40-55% of
+> trades with positive expectancy when its rules and risk caps are respected.
+> Anything claiming 90% on real, live, non-cherry-picked trades is almost
+> certainly fiction. The point of this scaffold is to *survive* the FTMO daily-
+> loss / total-loss rules while giving you a positive-expectancy edge to
+> compound.
+
+## What's in here
+
+| File | Purpose |
+| --- | --- |
+| `src/ftmo_oanda/config.py` | Loads OANDA + FTMO + trading config from `.env` |
+| `src/ftmo_oanda/oanda_client.py` | Minimal OANDA v20 REST client (candles, pricing, orders, positions) |
+| `src/ftmo_oanda/timeframe.py` | `TimeframeProfile` - auto-adjusts risk / leverage / ATR / EMA / cooldown by granularity |
+| `src/ftmo_oanda/risk.py` | `FtmoRiskManager` - daily-loss + total-loss + profit-target gates and position sizing |
+| `src/ftmo_oanda/strategies/ema_atr_trend.py` | EMA-cross trend strategy with ATR stop / target |
+| `src/ftmo_oanda/backtest.py` | Bar-by-bar backtester with realistic stats |
+| `src/ftmo_oanda/bot.py` | Live trading loop |
+| `src/ftmo_oanda/dashboard.py` | Rich terminal dashboard |
+| `tests/` | Unit tests for risk, strategy, timeframe, backtester |
+
+## Setup
+
+```bash
+cd ftmo_oanda
+python -m venv .venv && source .venv/bin/activate
+pip install -e .[dev]
+cp .env.example .env
+# edit .env with your OANDA practice token + FTMO challenge parameters
+```
+
+Get an OANDA practice token at <https://www.oanda.com/demo-account/tpa/personal_token>.
+**Always test on a practice account first.**
+
+## Run
+
+```bash
+# Backtest the configured timeframe on historical candles
+python scripts/run_backtest.py --instrument EUR_USD --tf H1 --bars 5000
+
+# Read-only dashboard
+python scripts/run_dashboard.py
+
+# Live bot - DRY_RUN=true (default) only logs intended orders
+python scripts/run_bot.py
+```
+
+To go live, set `DRY_RUN=false` in `.env`. The bot still refuses to place new
+trades when daily loss, total loss, or profit target gates are tripped.
+
+## How "auto-adjust by timeframe" works
+
+`for_timeframe(code)` returns a frozen `TimeframeProfile`. Lower timeframes get
+smaller risk-per-trade, tighter ATR multiples, faster EMAs, and lower effective
+leverage; higher timeframes get the opposite. Every other component reads from
+the active profile, so changing `TIMEFRAME=M15` to `TIMEFRAME=H4` in `.env`
+adjusts:
+
+- risk-per-trade (% of equity)
+- max effective leverage (capped further by FTMO + per-instrument margin rate)
+- ATR period and stop / target multipliers
+- EMA fast / slow lookbacks
+- bars to wait after a trade closes (cooldown)
+- max concurrent positions across the portfolio
+- candles requested per warmup
+
+| TF  | Risk/trade | Max lev | ATR stop / tgt | EMA F/S | Cooldown | Max concurrent |
+| --- | ---------- | ------- | -------------- | ------- | -------- | -------------- |
+| M1  | 0.10%      | 5x      | 1.5 / 2.25     | 8 / 21  | 10 bars  | 1              |
+| M5  | 0.20%      | 8x      | 1.75 / 2.75    | 12 / 34 | 6 bars   | 2              |
+| M15 | 0.30%      | 10x     | 2.0 / 3.0      | 20 / 50 | 4 bars   | 2              |
+| M30 | 0.40%      | 12x     | 2.0 / 3.0      | 20 / 50 | 3 bars   | 3              |
+| H1  | 0.50%      | 15x     | 2.0 / 3.5      | 21 / 55 | 3 bars   | 3              |
+| H4  | 0.75%      | 20x     | 2.5 / 4.0      | 21 / 55 | 2 bars   | 4              |
+| D   | 1.00%      | 25x     | 3.0 / 4.5      | 20 / 50 | 1 bar    | 5              |
+
+Tune the table in `timeframe.py` once you have a backtest you trust. The
+defaults err on the conservative side so the FTMO 5%-day / 10%-total caps
+absorb a normal losing streak.
+
+## FTMO guardrails
+
+`FtmoRiskManager.can_open_new_trade()` returns `False` when:
+
+- equity has dropped to the **total-loss floor** (`initial * (1 - max_total_loss_pct/100)`)
+- realized + unrealized losses since UTC midnight reach the **daily-loss budget**
+- equity has already crossed the **profit target** (stop trading, lock the pass)
+- open positions would exceed the timeframe's `max_concurrent_positions`
+
+Position sizing computes the integer number of units that risks
+`risk_per_trade_pct` of current equity over the planned stop distance, then
+clamps the notional by the *minimum* of: timeframe leverage, OANDA per-
+instrument leverage, and FTMO max leverage.
+
+## Tests
+
+```bash
+pytest -q
+```
+
+17 tests cover the pieces that don't need a live OANDA account: timeframe
+scaling, risk-manager guardrails, position sizing, strategy signals on
+synthetic data, and the backtester loop.
+
+## What this scaffold does **not** do
+
+- Forecast prices with deep learning. The strategy is a deliberately simple
+  EMA + ATR trend filter so you can see exactly why each trade fires.
+- Trade news / event windows differently. Add an FTMO news filter yourself
+  before going live.
+- Persist state across restarts. The risk manager rebuilds its day-start
+  equity from the OANDA account each launch.
+- Hedge. Each instrument trades one direction at a time.
+
+These are obvious next iterations once the basic loop is working on a demo
+account.

--- a/ftmo_oanda/pyproject.toml
+++ b/ftmo_oanda/pyproject.toml
@@ -1,0 +1,31 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ftmo-oanda"
+version = "0.1.0"
+description = "FTMO-aware OANDA v20 trading scaffold with timeframe-adaptive risk."
+requires-python = ">=3.10"
+dependencies = [
+  "requests>=2.31",
+  "pandas>=2.0",
+  "numpy>=1.24",
+  "python-dotenv>=1.0",
+  "rich>=13.0",
+  "pydantic>=2.0",
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.scripts]
+ftmo-bot = "ftmo_oanda.bot:main"
+ftmo-dashboard = "ftmo_oanda.dashboard:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]

--- a/ftmo_oanda/requirements.txt
+++ b/ftmo_oanda/requirements.txt
@@ -1,0 +1,6 @@
+requests>=2.31.0
+pandas>=2.0.0
+numpy>=1.24.0
+python-dotenv>=1.0.0
+rich>=13.0.0
+pydantic>=2.0.0

--- a/ftmo_oanda/scripts/run_backtest.py
+++ b/ftmo_oanda/scripts/run_backtest.py
@@ -1,0 +1,53 @@
+"""Entry point: backtest the strategy on historical OANDA candles.
+
+Usage:
+    python scripts/run_backtest.py --instrument EUR_USD --tf H1 --bars 5000
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+
+from ftmo_oanda.backtest import run_backtest
+from ftmo_oanda.config import AppConfig
+from ftmo_oanda.oanda_client import OandaClient
+from ftmo_oanda.risk import FtmoRiskManager
+from ftmo_oanda.timeframe import for_timeframe
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--instrument", default="EUR_USD")
+    parser.add_argument("--tf", default=None, help="Override TIMEFRAME from .env")
+    parser.add_argument("--bars", type=int, default=5000)
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    cfg = AppConfig.from_env()
+    tf = args.tf or cfg.trading.timeframe
+    profile = for_timeframe(tf)
+
+    client = OandaClient(cfg.oanda)
+    # OANDA caps a single candle request at 5000.
+    chunk = min(args.bars, 5000)
+    candles = client.candles(args.instrument, granularity=tf, count=chunk)
+    if candles.empty:
+        raise SystemExit(f"no candles returned for {args.instrument}/{tf}")
+
+    risk = FtmoRiskManager(cfg.ftmo, profile)
+    stats = run_backtest(candles, profile, risk, instrument=args.instrument)
+
+    print(f"\nBacktest: {args.instrument} {tf}  ({len(candles)} bars)")
+    print(f"  starting equity   {stats['starting_equity']:>14,.2f}")
+    print(f"  ending equity     {stats['ending_equity']:>14,.2f}")
+    print(f"  return            {stats['return_pct']:>14.2f}%")
+    print(f"  trades            {int(stats['trades']):>14d}")
+    print(f"  win rate          {stats['win_rate_pct']:>14.2f}%")
+    print(f"  expectancy        {stats['expectancy']:>14.2f}")
+    print(f"  profit factor     {stats['profit_factor']:>14.2f}")
+    print(f"  max drawdown      {stats['max_drawdown_pct']:>14.2f}%")
+    print(f"  avg win / loss    {stats['avg_win']:>7.2f} / {stats['avg_loss']:>7.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ftmo_oanda/scripts/run_bot.py
+++ b/ftmo_oanda/scripts/run_bot.py
@@ -1,0 +1,5 @@
+"""Entry point: live trading loop."""
+from ftmo_oanda.bot import main
+
+if __name__ == "__main__":
+    main()

--- a/ftmo_oanda/scripts/run_dashboard.py
+++ b/ftmo_oanda/scripts/run_dashboard.py
@@ -1,0 +1,5 @@
+"""Entry point: terminal dashboard."""
+from ftmo_oanda.dashboard import main
+
+if __name__ == "__main__":
+    main()

--- a/ftmo_oanda/src/ftmo_oanda/__init__.py
+++ b/ftmo_oanda/src/ftmo_oanda/__init__.py
@@ -1,0 +1,3 @@
+"""FTMO-aware OANDA v20 trading scaffold."""
+
+__version__ = "0.1.0"

--- a/ftmo_oanda/src/ftmo_oanda/backtest.py
+++ b/ftmo_oanda/src/ftmo_oanda/backtest.py
@@ -1,0 +1,157 @@
+"""Bar-by-bar backtester.
+
+Walks the strategy across historical candles, simulating one bracketed entry
+at a time per instrument. Each bar after entry checks whether the high or low
+hit the stop or target (stop is checked first when both are touched on the
+same bar - conservative).
+
+Outputs a summary dict with realistic stats: trades, win rate, expectancy,
+max drawdown, profit factor, average R, ending equity. **No 90% win rate
+miracles.**
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+
+import pandas as pd
+
+from .risk import FtmoRiskManager, TradeResult
+from .strategies.ema_atr_trend import EmaAtrTrendStrategy, Signal
+from .timeframe import TimeframeProfile
+
+
+@dataclass
+class OpenTrade:
+    instrument: str
+    side: str
+    units: int
+    entry: float
+    stop: float
+    target: float
+    opened_at: pd.Timestamp
+
+
+def _exit_price(bar: pd.Series, trade: OpenTrade) -> Optional[float]:
+    """Stop checked before target on the same bar (conservative)."""
+    high, low = float(bar["high"]), float(bar["low"])
+    if trade.side == "long":
+        if low <= trade.stop:
+            return trade.stop
+        if high >= trade.target:
+            return trade.target
+    else:
+        if high >= trade.stop:
+            return trade.stop
+        if low <= trade.target:
+            return trade.target
+    return None
+
+
+def run_backtest(
+    candles: pd.DataFrame,
+    profile: TimeframeProfile,
+    risk: FtmoRiskManager,
+    instrument: str = "EUR_USD",
+    pip_value_per_unit: float = 1.0,
+) -> Dict[str, float]:
+    """Run a single-instrument backtest. ``candles`` must have OHLC columns."""
+    strategy = EmaAtrTrendStrategy(profile)
+    df = strategy.annotate(candles).dropna()
+    if df.empty:
+        return {"error": "not enough bars after warmup"}
+
+    open_trade: Optional[OpenTrade] = None
+    cooldown = 0
+    equity_curve: List[float] = []
+
+    for ts, bar in df.iterrows():
+        # Manage open trade first.
+        if open_trade is not None:
+            ex = _exit_price(bar, open_trade)
+            if ex is not None:
+                pnl_per_unit = (
+                    (ex - open_trade.entry)
+                    if open_trade.side == "long"
+                    else (open_trade.entry - ex)
+                ) * pip_value_per_unit
+                pnl = pnl_per_unit * abs(open_trade.units)
+                risk.record_trade(
+                    TradeResult(
+                        instrument=instrument,
+                        units=open_trade.units,
+                        entry=open_trade.entry,
+                        exit=ex,
+                        pnl=pnl,
+                        opened_at=open_trade.opened_at.to_pydatetime(),
+                        closed_at=ts.to_pydatetime(),
+                    )
+                )
+                open_trade = None
+                cooldown = profile.cooldown_bars
+
+        equity_curve.append(risk.state.equity)
+
+        # Hard stop if FTMO total-loss breached.
+        if risk.state.equity <= risk.total_loss_floor:
+            break
+
+        if cooldown > 0:
+            cooldown -= 1
+            continue
+        if open_trade is not None:
+            continue
+
+        # Need a window ending at this bar to evaluate signal.
+        window = df.loc[:ts]
+        sig: Optional[Signal] = strategy.signal(window)
+        if sig is None:
+            continue
+
+        ok, _ = risk.can_open_new_trade()
+        if not ok:
+            continue
+
+        units = risk.position_size(sig.entry, sig.stop, pip_value_per_unit)
+        if units == 0:
+            continue
+        risk.state.open_positions += 1
+        open_trade = OpenTrade(
+            instrument=instrument,
+            side=sig.side,
+            units=units,
+            entry=sig.entry,
+            stop=sig.stop,
+            target=sig.target,
+            opened_at=ts,
+        )
+
+    return _summarize(risk, equity_curve)
+
+
+def _summarize(risk: FtmoRiskManager, equity_curve: List[float]) -> Dict[str, float]:
+    trades = risk.state.closed_trades
+    n = len(trades)
+    pnls = [t.pnl for t in trades]
+    wins = [p for p in pnls if p > 0]
+    losses = [p for p in pnls if p <= 0]
+    gross_win = sum(wins)
+    gross_loss = -sum(losses)
+
+    eq = pd.Series(equity_curve) if equity_curve else pd.Series([risk.state.equity])
+    peak = eq.cummax()
+    drawdown = (eq - peak) / peak
+    max_dd_pct = float(drawdown.min() * 100) if not drawdown.empty else 0.0
+
+    return {
+        "trades": float(n),
+        "win_rate_pct": (100.0 * len(wins) / n) if n else 0.0,
+        "avg_win": (gross_win / len(wins)) if wins else 0.0,
+        "avg_loss": (gross_loss / len(losses)) if losses else 0.0,
+        "expectancy": (sum(pnls) / n) if n else 0.0,
+        "profit_factor": (gross_win / gross_loss) if gross_loss > 0 else float("inf") if gross_win else 0.0,
+        "max_drawdown_pct": max_dd_pct,
+        "starting_equity": risk.state.initial_balance,
+        "ending_equity": risk.state.equity,
+        "return_pct": (risk.state.equity / risk.state.initial_balance - 1) * 100,
+    }

--- a/ftmo_oanda/src/ftmo_oanda/bot.py
+++ b/ftmo_oanda/src/ftmo_oanda/bot.py
@@ -1,0 +1,168 @@
+"""Live trading loop.
+
+Polls OANDA for fresh candles each bar, evaluates the strategy, and submits
+bracketed market orders if the FTMO risk manager approves. Defaults to
+``DRY_RUN=true`` so first runs print intended trades without sending them.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+from .config import AppConfig
+from .oanda_client import OandaClient
+from .risk import FtmoRiskManager
+from .strategies.ema_atr_trend import EmaAtrTrendStrategy
+from .timeframe import TimeframeProfile, for_timeframe, GRANULARITY_MINUTES
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class BotState:
+    last_signal_bar: Dict[str, str]  # instrument -> ISO timestamp string
+    cooldown_remaining: Dict[str, int]
+
+
+class Bot:
+    def __init__(self, cfg: AppConfig):
+        self.cfg = cfg
+        self.profile: TimeframeProfile = for_timeframe(cfg.trading.timeframe)
+        self.client = OandaClient(cfg.oanda)
+        summary = self.client.account_summary()
+        starting = float(summary.get("balance", cfg.ftmo.initial_balance))
+        self.risk = FtmoRiskManager(cfg.ftmo, self.profile, starting_equity=starting)
+        self.strategy = EmaAtrTrendStrategy(self.profile)
+        self.state = BotState(last_signal_bar={}, cooldown_remaining={})
+
+    # ------------------------------------------------------------------
+
+    def _sleep_until_next_bar(self) -> None:
+        """Coarse poll cadence: half the bar duration, capped to sane bounds."""
+        minutes = GRANULARITY_MINUTES.get(self.profile.granularity, 60)
+        sleep_s = max(15.0, min(60 * 60.0, minutes * 30.0))
+        log.debug("Sleeping %.1fs before next poll", sleep_s)
+        time.sleep(sleep_s)
+
+    def _refresh_equity(self) -> None:
+        try:
+            summary = self.client.account_summary()
+            equity = float(summary.get("NAV", summary.get("balance", 0)))
+            self.risk.update_equity(equity)
+            self.risk.state.open_positions = int(summary.get("openPositionCount", 0))
+        except Exception as exc:  # network blips shouldn't crash the loop
+            log.warning("Failed to refresh equity: %s", exc)
+
+    def _evaluate_instrument(self, instrument: str) -> None:
+        candles = self.client.candles(
+            instrument,
+            granularity=self.profile.granularity,
+            count=self.profile.candles_history,
+        )
+        if candles.empty:
+            log.warning("No candles for %s", instrument)
+            return
+
+        last_bar_time = candles.index[-1].isoformat()
+        if self.state.last_signal_bar.get(instrument) == last_bar_time:
+            return  # already evaluated this closed bar
+
+        cd = self.state.cooldown_remaining.get(instrument, 0)
+        if cd > 0:
+            self.state.cooldown_remaining[instrument] = cd - 1
+            self.state.last_signal_bar[instrument] = last_bar_time
+            return
+
+        sig = self.strategy.signal(candles)
+        self.state.last_signal_bar[instrument] = last_bar_time
+        if sig is None:
+            return
+
+        ok, reason = self.risk.can_open_new_trade()
+        if not ok:
+            log.info("Skip %s signal: %s", instrument, reason)
+            return
+
+        # Pull instrument metadata for accurate leverage caps.
+        try:
+            details = self.client.instrument_details(instrument)
+            margin_rate = float(details.get("marginRate", 0.05))
+            instr_leverage_cap = (1.0 / margin_rate) if margin_rate > 0 else None
+        except Exception:
+            instr_leverage_cap = None
+
+        units = self.risk.position_size(
+            entry_price=sig.entry,
+            stop_price=sig.stop,
+            pip_value_per_unit=1.0,  # quote-currency P&L per 1.0 price move
+            instrument_leverage_cap=instr_leverage_cap,
+        )
+        if units == 0:
+            log.info("Skip %s: position size rounds to zero", instrument)
+            return
+
+        log.info(
+            "%s %s entry=%.5f stop=%.5f target=%.5f units=%d (tf=%s, risk=%.2f%%)",
+            instrument,
+            sig.side.upper(),
+            sig.entry,
+            sig.stop,
+            sig.target,
+            units,
+            self.profile.granularity,
+            self.profile.risk_per_trade_pct,
+        )
+
+        if self.cfg.trading.dry_run:
+            log.info("[DRY_RUN] not sending order")
+        else:
+            try:
+                self.client.market_order(
+                    instrument=instrument,
+                    units=units,
+                    stop_loss=sig.stop,
+                    take_profit=sig.target,
+                    client_tag=f"ftmo-bot-{self.profile.granularity}",
+                )
+                self.risk.state.open_positions += 1
+                self.state.cooldown_remaining[instrument] = self.profile.cooldown_bars
+            except Exception as exc:
+                log.error("Order failed for %s: %s", instrument, exc)
+
+    # ------------------------------------------------------------------
+
+    def run_forever(self) -> None:
+        log.info(
+            "Bot starting: env=%s tf=%s instruments=%s dry_run=%s",
+            self.cfg.oanda.environment,
+            self.profile.granularity,
+            self.cfg.trading.instruments,
+            self.cfg.trading.dry_run,
+        )
+        while True:
+            self._refresh_equity()
+            ok, reason = self.risk.can_open_new_trade()
+            if not ok:
+                log.info("Trading halted: %s", reason)
+                # Continue running for monitoring even when halted.
+            for instrument in self.cfg.trading.instruments:
+                try:
+                    self._evaluate_instrument(instrument)
+                except Exception as exc:
+                    log.exception("Error evaluating %s: %s", instrument, exc)
+            self._sleep_until_next_bar()
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    cfg = AppConfig.from_env()
+    Bot(cfg).run_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/ftmo_oanda/src/ftmo_oanda/config.py
+++ b/ftmo_oanda/src/ftmo_oanda/config.py
@@ -1,0 +1,106 @@
+"""Environment-driven configuration."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import List
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def _env(name: str, default: str | None = None, required: bool = False) -> str:
+    val = os.getenv(name, default)
+    if required and not val:
+        raise RuntimeError(f"Missing required env var: {name}")
+    return val or ""
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    return float(raw) if raw not in (None, "") else default
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    return int(raw) if raw not in (None, "") else default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ("1", "true", "yes", "y", "on")
+
+
+@dataclass
+class OandaConfig:
+    api_token: str
+    account_id: str
+    environment: str = "practice"
+
+    @property
+    def rest_host(self) -> str:
+        return (
+            "https://api-fxtrade.oanda.com"
+            if self.environment == "live"
+            else "https://api-fxpractice.oanda.com"
+        )
+
+    @property
+    def stream_host(self) -> str:
+        return (
+            "https://stream-fxtrade.oanda.com"
+            if self.environment == "live"
+            else "https://stream-fxpractice.oanda.com"
+        )
+
+
+@dataclass
+class FtmoConfig:
+    initial_balance: float = 100_000.0
+    profit_target_pct: float = 10.0
+    max_daily_loss_pct: float = 5.0
+    max_total_loss_pct: float = 10.0
+    max_leverage: float = 30.0
+
+
+@dataclass
+class TradingConfig:
+    instruments: List[str] = field(default_factory=lambda: ["EUR_USD"])
+    timeframe: str = "H1"
+    dry_run: bool = True
+
+
+@dataclass
+class AppConfig:
+    oanda: OandaConfig
+    ftmo: FtmoConfig
+    trading: TradingConfig
+
+    @classmethod
+    def from_env(cls) -> "AppConfig":
+        return cls(
+            oanda=OandaConfig(
+                api_token=_env("OANDA_API_TOKEN", required=True),
+                account_id=_env("OANDA_ACCOUNT_ID", required=True),
+                environment=_env("OANDA_ENVIRONMENT", "practice"),
+            ),
+            ftmo=FtmoConfig(
+                initial_balance=_env_float("FTMO_INITIAL_BALANCE", 100_000.0),
+                profit_target_pct=_env_float("FTMO_PROFIT_TARGET_PCT", 10.0),
+                max_daily_loss_pct=_env_float("FTMO_MAX_DAILY_LOSS_PCT", 5.0),
+                max_total_loss_pct=_env_float("FTMO_MAX_TOTAL_LOSS_PCT", 10.0),
+                max_leverage=_env_float("FTMO_MAX_LEVERAGE", 30.0),
+            ),
+            trading=TradingConfig(
+                instruments=[
+                    s.strip()
+                    for s in _env("INSTRUMENTS", "EUR_USD").split(",")
+                    if s.strip()
+                ],
+                timeframe=_env("TIMEFRAME", "H1"),
+                dry_run=_env_bool("DRY_RUN", True),
+            ),
+        )

--- a/ftmo_oanda/src/ftmo_oanda/dashboard.py
+++ b/ftmo_oanda/src/ftmo_oanda/dashboard.py
@@ -1,0 +1,94 @@
+"""Terminal dashboard - read-only view of account, FTMO usage, and positions."""
+from __future__ import annotations
+
+import time
+
+from rich.console import Console
+from rich.live import Live
+from rich.panel import Panel
+from rich.table import Table
+
+from .config import AppConfig
+from .oanda_client import OandaClient
+from .timeframe import for_timeframe
+
+
+def _make_view(cfg: AppConfig, client: OandaClient) -> Panel:
+    profile = for_timeframe(cfg.trading.timeframe)
+    summary = client.account_summary()
+    positions = client.open_positions()
+
+    nav = float(summary.get("NAV", summary.get("balance", 0)))
+    bal = float(summary.get("balance", nav))
+    initial = cfg.ftmo.initial_balance
+    daily_loss_floor = bal * (cfg.ftmo.max_daily_loss_pct / 100)
+    total_loss_floor = initial * (1 - cfg.ftmo.max_total_loss_pct / 100)
+    target = initial * (1 + cfg.ftmo.profit_target_pct / 100)
+
+    acct = Table(title="Account", show_header=False, expand=True)
+    acct.add_column(style="cyan")
+    acct.add_column(justify="right")
+    acct.add_row("Environment", cfg.oanda.environment)
+    acct.add_row("Account ID", cfg.oanda.account_id)
+    acct.add_row("Balance", f"{bal:,.2f}")
+    acct.add_row("NAV (equity)", f"{nav:,.2f}")
+    acct.add_row("Open positions", str(summary.get("openPositionCount", 0)))
+    acct.add_row("Margin used", f"{float(summary.get('marginUsed', 0)):,.2f}")
+
+    ftmo = Table(title="FTMO guardrails", show_header=False, expand=True)
+    ftmo.add_column(style="cyan")
+    ftmo.add_column(justify="right")
+    ftmo.add_row("Profit target", f"{target:,.2f}")
+    ftmo.add_row("Total-loss floor", f"{total_loss_floor:,.2f}")
+    ftmo.add_row("Daily-loss budget", f"{daily_loss_floor:,.2f}")
+    ftmo.add_row("Distance to target", f"{nav - target:+,.2f}")
+    ftmo.add_row("Distance to total floor", f"{nav - total_loss_floor:+,.2f}")
+
+    tf = Table(title=f"Timeframe profile ({profile.granularity})", show_header=False, expand=True)
+    tf.add_column(style="cyan")
+    tf.add_column(justify="right")
+    tf.add_row("Risk per trade", f"{profile.risk_per_trade_pct:.2f}%")
+    tf.add_row("Max effective leverage", f"{profile.max_effective_leverage:.0f}x")
+    tf.add_row("ATR stop / target", f"{profile.atr_stop_mult} / {profile.atr_target_mult}")
+    tf.add_row("Reward:risk", f"{profile.reward_risk:.2f}")
+    tf.add_row("EMA fast / slow", f"{profile.ema_fast} / {profile.ema_slow}")
+    tf.add_row("Max concurrent", str(profile.max_concurrent_positions))
+
+    pos = Table(title="Open positions", expand=True)
+    pos.add_column("Instrument")
+    pos.add_column("Long units", justify="right")
+    pos.add_column("Short units", justify="right")
+    pos.add_column("Unrealized P&L", justify="right")
+    for p in positions:
+        pos.add_row(
+            p["instrument"],
+            p["long"]["units"],
+            p["short"]["units"],
+            f"{float(p.get('unrealizedPL', 0)):+,.2f}",
+        )
+    if not positions:
+        pos.add_row("(none)", "", "", "")
+
+    grid = Table.grid(expand=True)
+    grid.add_column(ratio=1)
+    grid.add_column(ratio=1)
+    grid.add_row(acct, ftmo)
+    grid.add_row(tf, pos)
+    return Panel(grid, title="FTMO / OANDA bot dashboard", border_style="green")
+
+
+def main() -> None:
+    cfg = AppConfig.from_env()
+    client = OandaClient(cfg.oanda)
+    console = Console()
+    with Live(_make_view(cfg, client), console=console, refresh_per_second=1) as live:
+        while True:
+            time.sleep(5)
+            try:
+                live.update(_make_view(cfg, client))
+            except Exception as exc:  # transient errors shouldn't kill the view
+                console.print(f"[red]refresh error: {exc}[/red]")
+
+
+if __name__ == "__main__":
+    main()

--- a/ftmo_oanda/src/ftmo_oanda/indicators.py
+++ b/ftmo_oanda/src/ftmo_oanda/indicators.py
@@ -1,0 +1,23 @@
+"""Pure-pandas technical indicators."""
+from __future__ import annotations
+
+import pandas as pd
+
+
+def ema(series: pd.Series, length: int) -> pd.Series:
+    return series.ewm(span=length, adjust=False).mean()
+
+
+def atr(df: pd.DataFrame, length: int = 14) -> pd.Series:
+    """Wilder-smoothed ATR. Expects columns: high, low, close."""
+    high, low, close = df["high"], df["low"], df["close"]
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [
+            high - low,
+            (high - prev_close).abs(),
+            (low - prev_close).abs(),
+        ],
+        axis=1,
+    ).max(axis=1)
+    return tr.ewm(alpha=1.0 / length, adjust=False).mean()

--- a/ftmo_oanda/src/ftmo_oanda/oanda_client.py
+++ b/ftmo_oanda/src/ftmo_oanda/oanda_client.py
@@ -1,0 +1,190 @@
+"""Minimal OANDA v20 REST client.
+
+Covers what the bot needs: account summary, candles, pricing, market orders
+with stop-loss / take-profit, open positions, and trade close.
+
+OANDA v20 API docs: https://developer.oanda.com/rest-live-v20/introduction/
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional
+
+import pandas as pd
+import requests
+
+from .config import OandaConfig
+
+log = logging.getLogger(__name__)
+
+
+class OandaError(RuntimeError):
+    pass
+
+
+@dataclass
+class Candle:
+    time: pd.Timestamp
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+
+
+class OandaClient:
+    def __init__(self, cfg: OandaConfig, session: Optional[requests.Session] = None):
+        self.cfg = cfg
+        self.session = session or requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": f"Bearer {cfg.api_token}",
+                "Content-Type": "application/json",
+                "Accept-Datetime-Format": "RFC3339",
+            }
+        )
+
+    # ---- low-level ---------------------------------------------------------
+
+    def _url(self, path: str, *, stream: bool = False) -> str:
+        host = self.cfg.stream_host if stream else self.cfg.rest_host
+        return f"{host}/v3{path}"
+
+    def _request(self, method: str, path: str, **kwargs: Any) -> Dict[str, Any]:
+        url = self._url(path)
+        resp = self.session.request(method, url, timeout=30, **kwargs)
+        if not resp.ok:
+            raise OandaError(f"{method} {path} -> {resp.status_code}: {resp.text}")
+        return resp.json() if resp.text else {}
+
+    # ---- account ----------------------------------------------------------
+
+    def account_summary(self) -> Dict[str, Any]:
+        data = self._request("GET", f"/accounts/{self.cfg.account_id}/summary")
+        return data["account"]
+
+    def instrument_details(self, instrument: str) -> Dict[str, Any]:
+        data = self._request(
+            "GET",
+            f"/accounts/{self.cfg.account_id}/instruments",
+            params={"instruments": instrument},
+        )
+        instruments = data.get("instruments", [])
+        if not instruments:
+            raise OandaError(f"Instrument not available on this account: {instrument}")
+        return instruments[0]
+
+    # ---- market data -------------------------------------------------------
+
+    def candles(
+        self,
+        instrument: str,
+        granularity: str = "H1",
+        count: int = 500,
+        price: str = "M",
+    ) -> pd.DataFrame:
+        """Fetch historical candles as a DataFrame indexed by time."""
+        params = {"granularity": granularity, "count": count, "price": price}
+        data = self._request(
+            "GET", f"/instruments/{instrument}/candles", params=params
+        )
+        rows = []
+        for c in data.get("candles", []):
+            if not c.get("complete", False):
+                continue
+            mid = c["mid"]
+            rows.append(
+                {
+                    "time": pd.to_datetime(c["time"], utc=True),
+                    "open": float(mid["o"]),
+                    "high": float(mid["h"]),
+                    "low": float(mid["l"]),
+                    "close": float(mid["c"]),
+                    "volume": int(c["volume"]),
+                }
+            )
+        df = pd.DataFrame(rows)
+        if not df.empty:
+            df = df.set_index("time").sort_index()
+        return df
+
+    def current_price(self, instrument: str) -> Dict[str, float]:
+        data = self._request(
+            "GET",
+            f"/accounts/{self.cfg.account_id}/pricing",
+            params={"instruments": instrument},
+        )
+        prices = data.get("prices", [])
+        if not prices:
+            raise OandaError(f"No price returned for {instrument}")
+        p = prices[0]
+        bid = float(p["bids"][0]["price"])
+        ask = float(p["asks"][0]["price"])
+        return {"bid": bid, "ask": ask, "mid": (bid + ask) / 2}
+
+    def stream_prices(self, instruments: List[str]) -> Iterator[Dict[str, Any]]:
+        url = self._url(
+            f"/accounts/{self.cfg.account_id}/pricing/stream", stream=True
+        )
+        params = {"instruments": ",".join(instruments)}
+        with self.session.get(url, params=params, stream=True, timeout=None) as resp:
+            if not resp.ok:
+                raise OandaError(f"stream {resp.status_code}: {resp.text}")
+            for line in resp.iter_lines():
+                if not line:
+                    continue
+                msg = json.loads(line)
+                if msg.get("type") == "PRICE":
+                    yield msg
+
+    # ---- orders / positions -----------------------------------------------
+
+    def market_order(
+        self,
+        instrument: str,
+        units: int,
+        stop_loss: Optional[float] = None,
+        take_profit: Optional[float] = None,
+        client_tag: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Place a market order. `units` is signed: positive=long, negative=short."""
+        order: Dict[str, Any] = {
+            "type": "MARKET",
+            "instrument": instrument,
+            "units": str(int(units)),
+            "timeInForce": "FOK",
+            "positionFill": "DEFAULT",
+        }
+        if stop_loss is not None:
+            order["stopLossOnFill"] = {"price": f"{stop_loss:.5f}"}
+        if take_profit is not None:
+            order["takeProfitOnFill"] = {"price": f"{take_profit:.5f}"}
+        if client_tag:
+            order["clientExtensions"] = {"tag": client_tag, "id": client_tag[:64]}
+
+        return self._request(
+            "POST",
+            f"/accounts/{self.cfg.account_id}/orders",
+            data=json.dumps({"order": order}),
+        )
+
+    def open_positions(self) -> List[Dict[str, Any]]:
+        data = self._request(
+            "GET", f"/accounts/{self.cfg.account_id}/openPositions"
+        )
+        return data.get("positions", [])
+
+    def close_position(self, instrument: str, side: str = "ALL") -> Dict[str, Any]:
+        """Close long/short/all units of a position. side: LONG, SHORT, or ALL."""
+        body: Dict[str, Any] = {}
+        if side in ("LONG", "ALL"):
+            body["longUnits"] = "ALL"
+        if side in ("SHORT", "ALL"):
+            body["shortUnits"] = "ALL"
+        return self._request(
+            "PUT",
+            f"/accounts/{self.cfg.account_id}/positions/{instrument}/close",
+            data=json.dumps(body),
+        )

--- a/ftmo_oanda/src/ftmo_oanda/risk.py
+++ b/ftmo_oanda/src/ftmo_oanda/risk.py
@@ -1,0 +1,184 @@
+"""FTMO-aware risk manager.
+
+Owns three responsibilities:
+
+1. Position sizing - converts a risk-% + stop-distance into integer units of
+   the instrument, respecting the timeframe profile's leverage cap and FTMO's
+   broker leverage cap.
+2. Pre-trade gating - refuses new trades when the daily-loss or total-loss
+   guardrails would be breached, or when max-concurrent-positions is hit.
+3. State tracking - records realized P&L per trade, equity high-water mark,
+   and the start-of-day balance used for the daily-loss check.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from typing import Dict, List, Optional
+
+from .config import FtmoConfig
+from .timeframe import TimeframeProfile
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class TradeResult:
+    instrument: str
+    units: int
+    entry: float
+    exit: float
+    pnl: float
+    opened_at: datetime
+    closed_at: datetime
+
+
+@dataclass
+class RiskState:
+    initial_balance: float
+    equity: float
+    high_water_equity: float
+    day_start_equity: float
+    day: date
+    open_positions: int = 0
+    closed_trades: List[TradeResult] = field(default_factory=list)
+
+
+class FtmoRiskManager:
+    def __init__(self, ftmo: FtmoConfig, profile: TimeframeProfile, starting_equity: Optional[float] = None):
+        self.ftmo = ftmo
+        self.profile = profile
+        bal = starting_equity if starting_equity is not None else ftmo.initial_balance
+        today = datetime.now(timezone.utc).date()
+        self.state = RiskState(
+            initial_balance=ftmo.initial_balance,
+            equity=bal,
+            high_water_equity=bal,
+            day_start_equity=bal,
+            day=today,
+        )
+
+    # ---- equity bookkeeping -----------------------------------------------
+
+    def roll_day_if_needed(self, now: Optional[datetime] = None) -> None:
+        now = now or datetime.now(timezone.utc)
+        if now.date() != self.state.day:
+            self.state.day = now.date()
+            self.state.day_start_equity = self.state.equity
+            log.info("New trading day %s, day-start equity=%.2f", self.state.day, self.state.equity)
+
+    def update_equity(self, equity: float) -> None:
+        self.state.equity = equity
+        if equity > self.state.high_water_equity:
+            self.state.high_water_equity = equity
+
+    def record_trade(self, result: TradeResult) -> None:
+        self.state.closed_trades.append(result)
+        self.update_equity(self.state.equity + result.pnl)
+        self.state.open_positions = max(0, self.state.open_positions - 1)
+
+    # ---- FTMO guardrails --------------------------------------------------
+
+    @property
+    def daily_loss_budget(self) -> float:
+        return self.state.day_start_equity * (self.ftmo.max_daily_loss_pct / 100.0)
+
+    @property
+    def total_loss_floor(self) -> float:
+        return self.state.initial_balance * (1 - self.ftmo.max_total_loss_pct / 100.0)
+
+    @property
+    def profit_target(self) -> float:
+        return self.state.initial_balance * (1 + self.ftmo.profit_target_pct / 100.0)
+
+    def daily_loss_used(self) -> float:
+        return max(0.0, self.state.day_start_equity - self.state.equity)
+
+    def total_loss_used(self) -> float:
+        return max(0.0, self.state.initial_balance - self.state.equity)
+
+    def can_open_new_trade(self) -> tuple[bool, str]:
+        """Hard gate before any new entry. Returns (ok, reason)."""
+        self.roll_day_if_needed()
+        if self.state.equity <= self.total_loss_floor:
+            return False, "FTMO max total loss breached"
+        if self.daily_loss_used() >= self.daily_loss_budget:
+            return False, "FTMO max daily loss reached"
+        if self.state.equity >= self.profit_target:
+            return False, "Profit target reached, stop trading"
+        if self.state.open_positions >= self.profile.max_concurrent_positions:
+            return False, "Max concurrent positions reached"
+        return True, "ok"
+
+    # ---- position sizing --------------------------------------------------
+
+    def position_size(
+        self,
+        entry_price: float,
+        stop_price: float,
+        pip_value_per_unit: float,
+        instrument_leverage_cap: Optional[float] = None,
+    ) -> int:
+        """Compute integer units to risk `risk_per_trade_pct` of equity.
+
+        Args:
+            entry_price: planned entry, in quote currency.
+            stop_price: planned stop-loss, in quote currency.
+            pip_value_per_unit: P&L per unit per 1.0 of price change in the
+                account currency. For most pairs this is ~1 unit of quote
+                currency per 1.0 price move; the bot uses the
+                ``account.marginRate`` and instrument metadata for accuracy
+                where needed. For backtests pass 1.0.
+            instrument_leverage_cap: per-instrument leverage cap from OANDA
+                instrument details, if known.
+
+        Returns:
+            Signed integer units. Positive for long (entry > stop), negative
+            for short. 0 if risk inputs are invalid.
+        """
+        stop_distance = abs(entry_price - stop_price)
+        if stop_distance <= 0 or self.state.equity <= 0:
+            return 0
+
+        risk_dollars = self.state.equity * (self.profile.risk_per_trade_pct / 100.0)
+        # P&L per unit if price moves by stop_distance.
+        loss_per_unit = stop_distance * pip_value_per_unit
+        if loss_per_unit <= 0:
+            return 0
+
+        units = risk_dollars / loss_per_unit
+
+        # Leverage cap: notional <= equity * effective_leverage.
+        leverage_cap = self.profile.max_effective_leverage
+        if instrument_leverage_cap is not None:
+            leverage_cap = min(leverage_cap, instrument_leverage_cap)
+        leverage_cap = min(leverage_cap, self.ftmo.max_leverage)
+
+        max_notional = self.state.equity * leverage_cap
+        max_units_by_leverage = max_notional / max(entry_price, 1e-9)
+        units = min(units, max_units_by_leverage)
+
+        signed = int(units) if entry_price > stop_price else -int(units)
+        return signed
+
+    # ---- summary ----------------------------------------------------------
+
+    def status(self) -> Dict[str, float]:
+        wins = [t for t in self.state.closed_trades if t.pnl > 0]
+        losses = [t for t in self.state.closed_trades if t.pnl <= 0]
+        n = len(self.state.closed_trades)
+        return {
+            "equity": self.state.equity,
+            "high_water": self.state.high_water_equity,
+            "day_start": self.state.day_start_equity,
+            "daily_loss_used": self.daily_loss_used(),
+            "daily_loss_budget": self.daily_loss_budget,
+            "total_loss_used": self.total_loss_used(),
+            "total_loss_floor": self.total_loss_floor,
+            "profit_target": self.profit_target,
+            "trades": float(n),
+            "win_rate_pct": (100.0 * len(wins) / n) if n else 0.0,
+            "avg_win": (sum(t.pnl for t in wins) / len(wins)) if wins else 0.0,
+            "avg_loss": (sum(t.pnl for t in losses) / len(losses)) if losses else 0.0,
+        }

--- a/ftmo_oanda/src/ftmo_oanda/strategies/__init__.py
+++ b/ftmo_oanda/src/ftmo_oanda/strategies/__init__.py
@@ -1,0 +1,3 @@
+from .ema_atr_trend import EmaAtrTrendStrategy, Signal
+
+__all__ = ["EmaAtrTrendStrategy", "Signal"]

--- a/ftmo_oanda/src/ftmo_oanda/strategies/ema_atr_trend.py
+++ b/ftmo_oanda/src/ftmo_oanda/strategies/ema_atr_trend.py
@@ -1,0 +1,89 @@
+"""EMA-crossover trend strategy with ATR-based stops and targets.
+
+Signal rules (evaluated on the most recent *closed* bar):
+
+- Long  when ema_fast > ema_slow AND close > ema_slow AND ema_fast slope > 0
+- Short when ema_fast < ema_slow AND close < ema_slow AND ema_fast slope < 0
+- Otherwise flat.
+
+Stop and target are derived from the timeframe's ATR multipliers, so a 5m
+profile gets tighter brackets than an H4 profile automatically.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+import pandas as pd
+
+from ..indicators import atr, ema
+from ..timeframe import TimeframeProfile
+
+
+@dataclass
+class Signal:
+    side: str  # "long" or "short"
+    entry: float
+    stop: float
+    target: float
+    atr: float
+
+
+class EmaAtrTrendStrategy:
+    name = "ema_atr_trend"
+
+    def __init__(self, profile: TimeframeProfile):
+        self.profile = profile
+
+    def required_bars(self) -> int:
+        return max(self.profile.ema_slow, self.profile.atr_period) + 5
+
+    def annotate(self, candles: pd.DataFrame) -> pd.DataFrame:
+        df = candles.copy()
+        df["ema_fast"] = ema(df["close"], self.profile.ema_fast)
+        df["ema_slow"] = ema(df["close"], self.profile.ema_slow)
+        df["atr"] = atr(df, self.profile.atr_period)
+        df["ema_fast_slope"] = df["ema_fast"].diff()
+        return df
+
+    def signal(self, candles: pd.DataFrame) -> Optional[Signal]:
+        if len(candles) < self.required_bars():
+            return None
+        df = self.annotate(candles).dropna()
+        if df.empty:
+            return None
+
+        last = df.iloc[-1]
+        close = float(last["close"])
+        a = float(last["atr"])
+        if a <= 0:
+            return None
+
+        stop_dist = self.profile.atr_stop_mult * a
+        target_dist = self.profile.atr_target_mult * a
+
+        if (
+            last["ema_fast"] > last["ema_slow"]
+            and close > last["ema_slow"]
+            and last["ema_fast_slope"] > 0
+        ):
+            return Signal(
+                side="long",
+                entry=close,
+                stop=close - stop_dist,
+                target=close + target_dist,
+                atr=a,
+            )
+        if (
+            last["ema_fast"] < last["ema_slow"]
+            and close < last["ema_slow"]
+            and last["ema_fast_slope"] < 0
+        ):
+            return Signal(
+                side="short",
+                entry=close,
+                stop=close + stop_dist,
+                target=close - target_dist,
+                atr=a,
+            )
+        return None

--- a/ftmo_oanda/src/ftmo_oanda/timeframe.py
+++ b/ftmo_oanda/src/ftmo_oanda/timeframe.py
@@ -1,0 +1,191 @@
+"""Timeframe-aware trading profiles.
+
+Auto-adjusts risk-per-trade, effective leverage, ATR-stop multipliers, EMA
+lookbacks, signal cooldown and maximum concurrent positions based on the
+chosen OANDA candle granularity.
+
+Lower timeframes -> more signals -> smaller risk-per-trade and tighter stops.
+Higher timeframes -> fewer signals -> larger risk-per-trade and wider stops.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+# Mapping of OANDA granularity codes to approximate minutes-per-bar.
+GRANULARITY_MINUTES: Dict[str, int] = {
+    "S5": 1 / 12,
+    "S10": 1 / 6,
+    "S30": 0.5,
+    "M1": 1,
+    "M5": 5,
+    "M15": 15,
+    "M30": 30,
+    "H1": 60,
+    "H4": 240,
+    "H12": 720,
+    "D": 1440,
+    "W": 10080,
+}
+
+
+@dataclass(frozen=True)
+class TimeframeProfile:
+    """Settings derived from a timeframe.
+
+    Attributes:
+        granularity: OANDA candle code (e.g. "M15", "H1").
+        minutes_per_bar: minutes covered by one bar.
+        risk_per_trade_pct: % of account equity risked per trade.
+        max_effective_leverage: leverage cap *this profile* will use, bounded
+            by the broker / FTMO cap supplied by the risk manager.
+        atr_period: ATR lookback in bars.
+        atr_stop_mult: ATR multiples used for the stop-loss distance.
+        atr_target_mult: ATR multiples used for the take-profit distance
+            (this gives a constant reward:risk ratio = target/stop).
+        ema_fast: fast EMA lookback.
+        ema_slow: slow EMA lookback.
+        cooldown_bars: bars to wait after a trade closes before a new entry
+            on the same instrument.
+        max_concurrent_positions: cap across all instruments.
+        candles_history: how many bars to pull when warming up.
+    """
+
+    granularity: str
+    minutes_per_bar: float
+    risk_per_trade_pct: float
+    max_effective_leverage: float
+    atr_period: int
+    atr_stop_mult: float
+    atr_target_mult: float
+    ema_fast: int
+    ema_slow: int
+    cooldown_bars: int
+    max_concurrent_positions: int
+    candles_history: int
+
+    @property
+    def reward_risk(self) -> float:
+        return self.atr_target_mult / self.atr_stop_mult
+
+
+# Hand-tuned profiles. Numbers err on the conservative side for FTMO:
+# - daily-loss rule means many small losers must not blow the 5% cap;
+# - the bot caps risk-per-trade well below the worst-case daily budget;
+# - leverage stays well under FTMO's broker cap.
+_PROFILES: Dict[str, TimeframeProfile] = {
+    "M1": TimeframeProfile(
+        granularity="M1",
+        minutes_per_bar=1,
+        risk_per_trade_pct=0.10,
+        max_effective_leverage=5,
+        atr_period=14,
+        atr_stop_mult=1.5,
+        atr_target_mult=2.25,
+        ema_fast=8,
+        ema_slow=21,
+        cooldown_bars=10,
+        max_concurrent_positions=1,
+        candles_history=500,
+    ),
+    "M5": TimeframeProfile(
+        granularity="M5",
+        minutes_per_bar=5,
+        risk_per_trade_pct=0.20,
+        max_effective_leverage=8,
+        atr_period=14,
+        atr_stop_mult=1.75,
+        atr_target_mult=2.75,
+        ema_fast=12,
+        ema_slow=34,
+        cooldown_bars=6,
+        max_concurrent_positions=2,
+        candles_history=500,
+    ),
+    "M15": TimeframeProfile(
+        granularity="M15",
+        minutes_per_bar=15,
+        risk_per_trade_pct=0.30,
+        max_effective_leverage=10,
+        atr_period=14,
+        atr_stop_mult=2.0,
+        atr_target_mult=3.0,
+        ema_fast=20,
+        ema_slow=50,
+        cooldown_bars=4,
+        max_concurrent_positions=2,
+        candles_history=500,
+    ),
+    "M30": TimeframeProfile(
+        granularity="M30",
+        minutes_per_bar=30,
+        risk_per_trade_pct=0.40,
+        max_effective_leverage=12,
+        atr_period=14,
+        atr_stop_mult=2.0,
+        atr_target_mult=3.0,
+        ema_fast=20,
+        ema_slow=50,
+        cooldown_bars=3,
+        max_concurrent_positions=3,
+        candles_history=500,
+    ),
+    "H1": TimeframeProfile(
+        granularity="H1",
+        minutes_per_bar=60,
+        risk_per_trade_pct=0.50,
+        max_effective_leverage=15,
+        atr_period=14,
+        atr_stop_mult=2.0,
+        atr_target_mult=3.5,
+        ema_fast=21,
+        ema_slow=55,
+        cooldown_bars=3,
+        max_concurrent_positions=3,
+        candles_history=500,
+    ),
+    "H4": TimeframeProfile(
+        granularity="H4",
+        minutes_per_bar=240,
+        risk_per_trade_pct=0.75,
+        max_effective_leverage=20,
+        atr_period=14,
+        atr_stop_mult=2.5,
+        atr_target_mult=4.0,
+        ema_fast=21,
+        ema_slow=55,
+        cooldown_bars=2,
+        max_concurrent_positions=4,
+        candles_history=400,
+    ),
+    "D": TimeframeProfile(
+        granularity="D",
+        minutes_per_bar=1440,
+        risk_per_trade_pct=1.00,
+        max_effective_leverage=25,
+        atr_period=14,
+        atr_stop_mult=3.0,
+        atr_target_mult=4.5,
+        ema_fast=20,
+        ema_slow=50,
+        cooldown_bars=1,
+        max_concurrent_positions=5,
+        candles_history=300,
+    ),
+}
+
+
+def for_timeframe(granularity: str) -> TimeframeProfile:
+    """Return the profile for an OANDA granularity, raising on unknown codes."""
+    key = granularity.upper()
+    if key not in _PROFILES:
+        raise ValueError(
+            f"Unsupported timeframe '{granularity}'. "
+            f"Choose one of: {', '.join(_PROFILES)}"
+        )
+    return _PROFILES[key]
+
+
+def all_profiles() -> Dict[str, TimeframeProfile]:
+    return dict(_PROFILES)

--- a/ftmo_oanda/tests/test_backtest.py
+++ b/ftmo_oanda/tests/test_backtest.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+
+from ftmo_oanda.backtest import run_backtest
+from ftmo_oanda.config import FtmoConfig
+from ftmo_oanda.risk import FtmoRiskManager
+from ftmo_oanda.timeframe import for_timeframe
+
+
+def _ohlc(close):
+    idx = pd.date_range("2024-01-01", periods=len(close), freq="h", tz="UTC")
+    c = np.asarray(close, dtype=float)
+    h = c + 0.0005
+    l = c - 0.0005
+    return pd.DataFrame({"open": c, "high": h, "low": l, "close": c, "volume": 100}, index=idx)
+
+
+def test_backtest_runs_and_reports_stats():
+    profile = for_timeframe("H1")
+    risk = FtmoRiskManager(FtmoConfig(), profile)
+    # Trending then mean-reverting series, gives at least some signals.
+    series = np.concatenate([np.linspace(1.10, 1.30, 600), np.linspace(1.30, 1.10, 600)])
+    candles = _ohlc(series)
+    stats = run_backtest(candles, profile, risk, instrument="EUR_USD", pip_value_per_unit=1.0)
+    assert "trades" in stats
+    assert stats["starting_equity"] == 100_000.0
+    # Don't assert profitability - that would be cherry-picking.
+    assert stats["trades"] >= 0

--- a/ftmo_oanda/tests/test_risk.py
+++ b/ftmo_oanda/tests/test_risk.py
@@ -1,0 +1,90 @@
+from datetime import datetime, timedelta, timezone
+
+from ftmo_oanda.config import FtmoConfig
+from ftmo_oanda.risk import FtmoRiskManager, TradeResult
+from ftmo_oanda.timeframe import for_timeframe
+
+
+def _mgr(equity: float = 100_000.0) -> FtmoRiskManager:
+    return FtmoRiskManager(FtmoConfig(), for_timeframe("H1"), starting_equity=equity)
+
+
+def test_position_size_respects_risk_per_trade():
+    mgr = _mgr()
+    units = mgr.position_size(entry_price=1.1000, stop_price=1.0950, pip_value_per_unit=1.0)
+    # Risk = 0.50% of 100k = 500. stop_distance = 0.0050. units ~= 500/0.0050 = 100_000
+    # But leverage cap (15x equity / entry) = 1_500_000 / 1.1 ~= 1.36M, doesn't bind.
+    assert 95_000 <= units <= 105_000
+
+
+def test_position_size_capped_by_leverage():
+    mgr = _mgr(equity=1_000.0)
+    # Tight stop forces huge size by risk math, but leverage clamps it.
+    units = mgr.position_size(entry_price=1.10, stop_price=1.0999, pip_value_per_unit=1.0)
+    max_notional = 1_000.0 * mgr.profile.max_effective_leverage
+    assert units * 1.10 <= max_notional + 1
+
+
+def test_short_returns_negative_units():
+    mgr = _mgr()
+    units = mgr.position_size(entry_price=1.1000, stop_price=1.1050, pip_value_per_unit=1.0)
+    assert units < 0
+
+
+def test_invalid_inputs_yield_zero_units():
+    mgr = _mgr()
+    assert mgr.position_size(1.1, 1.1, 1.0) == 0
+    assert mgr.position_size(1.1, 1.0, 0.0) == 0
+
+
+def test_daily_loss_blocks_new_trades():
+    mgr = _mgr()
+    # Simulate a loss equal to the daily budget.
+    mgr.update_equity(mgr.state.equity - mgr.daily_loss_budget)
+    ok, reason = mgr.can_open_new_trade()
+    assert not ok
+    assert "daily" in reason.lower()
+
+
+def test_total_loss_blocks_new_trades():
+    mgr = _mgr()
+    mgr.update_equity(mgr.total_loss_floor - 1)
+    ok, reason = mgr.can_open_new_trade()
+    assert not ok
+    assert "total" in reason.lower()
+
+
+def test_profit_target_halts_trading():
+    mgr = _mgr()
+    mgr.update_equity(mgr.profit_target + 1)
+    ok, reason = mgr.can_open_new_trade()
+    assert not ok
+    assert "target" in reason.lower()
+
+
+def test_day_roll_resets_day_start_equity():
+    mgr = _mgr()
+    mgr.state.equity = 99_000
+    mgr.state.day_start_equity = 100_000
+    future = datetime.now(timezone.utc) + timedelta(days=1)
+    mgr.roll_day_if_needed(future)
+    assert mgr.state.day_start_equity == 99_000
+
+
+def test_record_trade_updates_equity_and_open_count():
+    mgr = _mgr()
+    mgr.state.open_positions = 1
+    now = datetime.now(timezone.utc)
+    mgr.record_trade(
+        TradeResult(
+            instrument="EUR_USD",
+            units=1000,
+            entry=1.10,
+            exit=1.11,
+            pnl=10.0,
+            opened_at=now,
+            closed_at=now,
+        )
+    )
+    assert mgr.state.equity == 100_010.0
+    assert mgr.state.open_positions == 0

--- a/ftmo_oanda/tests/test_strategy.py
+++ b/ftmo_oanda/tests/test_strategy.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pandas as pd
+
+from ftmo_oanda.strategies.ema_atr_trend import EmaAtrTrendStrategy
+from ftmo_oanda.timeframe import for_timeframe
+
+
+def _candles(prices):
+    idx = pd.date_range("2024-01-01", periods=len(prices), freq="h", tz="UTC")
+    p = np.asarray(prices, dtype=float)
+    high = p + 0.001
+    low = p - 0.001
+    return pd.DataFrame(
+        {"open": p, "high": high, "low": low, "close": p, "volume": 100},
+        index=idx,
+    )
+
+
+def test_long_signal_on_clear_uptrend():
+    profile = for_timeframe("H1")
+    df = _candles(np.linspace(1.10, 1.20, 200))
+    sig = EmaAtrTrendStrategy(profile).signal(df)
+    assert sig is not None
+    assert sig.side == "long"
+    assert sig.target > sig.entry > sig.stop
+
+
+def test_short_signal_on_clear_downtrend():
+    profile = for_timeframe("H1")
+    df = _candles(np.linspace(1.20, 1.10, 200))
+    sig = EmaAtrTrendStrategy(profile).signal(df)
+    assert sig is not None
+    assert sig.side == "short"
+    assert sig.stop > sig.entry > sig.target
+
+
+def test_no_signal_on_flat_market():
+    profile = for_timeframe("H1")
+    df = _candles([1.10] * 200)
+    assert EmaAtrTrendStrategy(profile).signal(df) is None
+
+
+def test_required_bars_returned_when_too_few():
+    profile = for_timeframe("H1")
+    df = _candles([1.10, 1.11, 1.12])
+    assert EmaAtrTrendStrategy(profile).signal(df) is None

--- a/ftmo_oanda/tests/test_timeframe.py
+++ b/ftmo_oanda/tests/test_timeframe.py
@@ -1,0 +1,29 @@
+import pytest
+
+from ftmo_oanda.timeframe import all_profiles, for_timeframe
+
+
+def test_all_known_timeframes_resolve():
+    for code in ["M1", "M5", "M15", "M30", "H1", "H4", "D"]:
+        p = for_timeframe(code)
+        assert p.granularity == code
+        assert p.atr_target_mult > p.atr_stop_mult, "reward should exceed risk"
+        assert p.ema_fast < p.ema_slow
+        assert p.risk_per_trade_pct > 0
+        assert p.max_effective_leverage > 0
+
+
+def test_unknown_timeframe_rejected():
+    with pytest.raises(ValueError):
+        for_timeframe("M2")
+
+
+def test_profiles_scale_with_timeframe():
+    profiles = all_profiles()
+    # Risk-per-trade should be monotonically non-decreasing from M1 -> D.
+    order = ["M1", "M5", "M15", "M30", "H1", "H4", "D"]
+    risks = [profiles[c].risk_per_trade_pct for c in order]
+    assert risks == sorted(risks), f"risk-per-trade not monotonic: {risks}"
+    # Same for leverage cap.
+    levs = [profiles[c].max_effective_leverage for c in order]
+    assert levs == sorted(levs), f"leverage cap not monotonic: {levs}"


### PR DESCRIPTION
## Summary

A realistic algorithmic trading bot that targets the **FTMO challenge via the OANDA v20 API**. Trade size, risk-per-trade, effective leverage, ATR stops/targets, EMA lookbacks, signal cooldown, and max concurrent positions **auto-adjust to the chosen timeframe** (M1 → D).

> **Honest expectation-setting.** This is *not* the viral "90% win rate" system from the Instagram reel — those claims almost never hold up under scrutiny. This scaffold targets ~40-55% win rate with positive expectancy and, more importantly, *survives* FTMO's 5%-day / 10%-total drawdown rules.

## What's included

- `oanda_client.py` — minimal OANDA v20 REST client (account, candles, pricing, market orders with SL/TP, positions)
- `timeframe.py` — `TimeframeProfile` table; lower TFs get smaller risk and tighter stops, higher TFs get larger risk and wider stops
- `risk.py` — `FtmoRiskManager` enforcing daily-loss budget, total-loss floor, profit-target halt, max-concurrent-positions, and computing position size from risk-% + stop distance, capped by leverage
- `strategies/ema_atr_trend.py` — EMA-cross trend filter with ATR stop and target
- `backtest.py` — bar-by-bar backtester reporting realistic stats (win-rate, expectancy, profit factor, max DD)
- `bot.py` — live loop, defaults to `DRY_RUN=true` so first runs only log intended trades
- `dashboard.py` — Rich terminal dashboard (account, FTMO usage, active timeframe profile, open positions)
- 17 unit tests covering risk guardrails, position sizing, strategy, timeframe scaling, backtester

## Auto-adjust by timeframe

Change `TIMEFRAME=M15` to `TIMEFRAME=H4` in `.env` and the entire system reconfigures:

| TF  | Risk/trade | Max lev | ATR stop/tgt | EMA F/S | Cooldown | Max concurrent |
| --- | ---------- | ------- | ------------ | ------- | -------- | -------------- |
| M1  | 0.10%      | 5x      | 1.5 / 2.25   | 8 / 21  | 10 bars  | 1              |
| M5  | 0.20%      | 8x      | 1.75 / 2.75  | 12 / 34 | 6 bars   | 2              |
| M15 | 0.30%      | 10x     | 2.0 / 3.0    | 20 / 50 | 4 bars   | 2              |
| H1  | 0.50%      | 15x     | 2.0 / 3.5    | 21 / 55 | 3 bars   | 3              |
| H4  | 0.75%      | 20x     | 2.5 / 4.0    | 21 / 55 | 2 bars   | 4              |
| D   | 1.00%      | 25x     | 3.0 / 4.5    | 20 / 50 | 1 bar    | 5              |

## Test plan

- [x] Unit tests pass: `cd ftmo_oanda && pytest -q` → 17 passed
- [ ] Smoke test against an OANDA practice account: `python scripts/run_dashboard.py`
- [ ] Backtest a realistic instrument: `python scripts/run_backtest.py --instrument EUR_USD --tf H1 --bars 5000`
- [ ] Run live loop with `DRY_RUN=true` for at least one full session and inspect logged signals
- [ ] Switch `DRY_RUN=false` only on a practice account, verify orders include SL/TP brackets
- [ ] Validate FTMO rule gates by manually setting equity below `total_loss_floor` and confirming new trades are refused

## Not in this PR (good follow-ups)

- News / event-window filter (FTMO restricts trading around scheduled high-impact news)
- Persistent state across restarts (today the bot rebuilds equity from OANDA on launch)
- Hedging / pyramiding (one direction per instrument)
- Strategy alternatives — only one EMA+ATR trend strategy is included

https://claude.ai/code/session_01SLCjiGpdrVX9reukVFHo6u

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLCjiGpdrVX9reukVFHo6u)_